### PR TITLE
Updates to admin data reproducibility scale

### DIFF
--- a/03-assess.Rmd
+++ b/03-assess.Rmd
@@ -233,7 +233,7 @@ Take note of the following concepts in this section:
 
 Each level of computational reproducibility is defined by the availability of data and materials, and whether or not the available materials faithfully reproduce the output of interest. The description of each level also includes possible improvements that can help advance the reproducibility of the output to a higher level. You will learn in more detail about the possible improvements. 
 
-Note that the assessment is made *at the output level* -- a paper can be highly reproducible for its main results, but suffer from low reproducibility for other outputs. The assessment includes a 10-point scale, where 0 represents that, under current circumstances, reproducers cannot access any reproduction package, while 10 represents access to all the materials and being able to reproduce the target outcome from the raw data.
+Note that the assessment is made *at the output level* -- a paper can be highly reproducible for its main results, but suffer from low reproducibility for other outputs. The assessment includes a 10-point scale, where 1 represents that, under current circumstances, reproducers cannot access any reproduction package, while 10 represents access to all the materials and being able to reproduce the target outcome from the raw data.
 
  - **Level 1 (L1):** No data or code are available. Possible improvements include adding: raw data (+AD), analysis data (+RD), cleaning code (+CC), and analysis code (+AC).
  
@@ -288,6 +288,28 @@ You may disagree with some of the levels outlined above, particularly wherever s
 
 #### Adjusting Levels To Account for Proprietary/Confidential Data {-}
 
+A large fraction of published research in economics is done using confidential and/or proprietary data. The most common type of such data is government data on tax records or provision of services, usually referred to as *administrative data*. Given that administrative and proprietary data are usually not publicly accessible, some of the reproducibility levels presented above need to be modified before applying them to outputs based on such data. The underlying theme in these modifications is that when data cannot be provided, reproducers can assign reproducibility scores based on the level of detail included in the instructions to obtain access to the data. Similarly, when reproducibility cannot be verified based on publicly available materials, the reproduction materials should demonstrate that a competent and unbiased third party (not involved in the original research team) was able to reproduce the results.
+
+ - **Levels 1 and 2** can be applied as described above.
+ 
+ - **Adjusted Level 3 (L3\*):** All the analysis code is provided, but only partial instructions on how to access the ***analysis data*** are available. This means that the authors have provided some, but not all of the following information:
+    a. *Contact information*, including name of the organization(s) that provides access to the data and contact information of at least one specific person.
+    b. *Terms of use*, including licenses and eligibility criteria to access the data, if any. 
+    c. *Information on data files (meta-data)*, including name(s) and number of files, file size, relevant version of file(s), and number of variables and observations in each file. Though not required, other relevant information may be included, including description dataset dictionary, summary statistics, and sythetic data (fake data with the same statistical properties as the original data)
+    d. *Estimated costs for access*, including monetary costs on fees and licences required to access the data, and non-monetary costs like wait times and specific geographical locations where there researchers need to be to access the data.  
+
+ - **Adjusted Level 4 (L4\*):** All the analysis code is provided, and complete and detailed instructions on how to access the *analysis data* are available.
+
+ - **Adjusted Level 5 (L5\*):** All requirements for Level 4\* are met, and the authors provide a certification that the output can be reproduced from the analysis data (CRA) by a third party. Examples include a signed letter by a disinterested reproducer or an official reproducibility certificate from a certification agency for data and code (eg., see [cascad](https://www.cascad.tech/)).
+ 
+ - **Levels 6 and 7** can be applied as described above.
+
+ - **Adjusted Level 8 (L8\*):** All requirements for Level 7\* are met and the authors provide incomplete instructions on how to access the ***raw*** data. Use the instructions described in Level 3 above to assess the completeness of the instructions.
+
+ - **Adjusted Level 9 (L9\*):**  All requirements for Level 8\* are met and the authors provide complete instructions on how to access the ***raw*** data. 
+
+ - **Adjusted Level 10 (L10\*):** All requirements for Level 9\* are met and the authors provide a certification that the output can be reproduced from the raw data. 
+ 
          Levels of Computational Reproducibility with Propietary/Confidential Data 
                        (P denotes "partial", C denotes "complete")    
 
@@ -310,30 +332,6 @@ You may disagree with some of the levels outlined above, particularly wherever s
     L8*: Some instr. for raw data....| ✔   ✔  | ✔    ✔  |  ✔  |  ✔    ✔ | ✔   - |  -  |
     L9*: All instr. for raw data.....| ✔   ✔  | ✔    ✔  |  ✔  |  ✔    ✔ | ✔   ✔ |  -  |
     L10*:Proof of third party CRR....| ✔   ✔  | ✔    ✔  |  ✔  |  ✔    ✔ | ✔   ✔ |  ✔  |
-
-A large fraction of published research in economics is done using confidential and/or proprietary data. The most common type of such data is government data on tax records or provision of services, usually referred as administrative data. Given the nature of this data, some of the levels from the guidelines need to be modified. The underlying theme in these modifications is that when data cannot be provided, materials will be assessed on how detailed are the instructions to obtain access. Similarly, when reproducibility cannot be verified publicly, the reproduction materials should demonstrate that a third party (not involved in the original research team) was able to reproduce the results. 
-
-
- - **Adjusted Level 3 (L3\*):** All the analysis code is provided, but only partial instructions on how to access the analysis data are available. To achieve partial status, the reproduction package should include the following information: 
-    1. *Partial contact information:* name of the organization where to obtain data and contact information of at least one specific person.  
-    2. *Partial information on data files (meta-data):* number, file size, number of variables and observations in each file.   
-    3. *Partial estimated costs:* monetary costs on fees and licences required to access the data, and non-monetary costs like wait times and specific geographical locations where there researchers need to be to access the data.  
-
- - **Adjusted Level 4 (L4\*):** All the analysis code is provided, but only partial instructions on how to access the analysis data are available. To achieve complete status, the reproduction package should have enough information that will allow others researchers to access the data without having to duplicate previous tasks. This should include the following information: 
-    1. *Contact information:* name of the organization where to obtain data and contact information of at least one specific person. Sample request forms, data use agreements and detail procedures on who should be contacted when.   
-    2. *Information on data files (meta-data):* number, file size, number of variables and observations in each file. Detailed summary description of each variable (dictionary), and summary statistics. If possible a synthetic data set (fake data with the same statistical properties as the original data) should be provided in the reproduction package.  
-    3. *Estimated costs:* monetary costs on fees and licences to access the data and non-monetary costs like wait times and specific geographical locations where there researchers need to be to access the data. The description on costs should be detailed providing a timeline and estimated costs at the different steps involved in obtaining the data. 
-
-
- - **Adjusted Level 5 (L5\*):** Level 4\* + the reproduction package includes a certification that the output can be reproduced from the analysis data (CRA) by a third party research (not part involved in the original research team). Examples include a signed letter by a colleague of one of the researchers in the original team, or more professional certificates offered by some organization (eg., see [cascad](https://www.cascad.tech/))  
-
- - **Adjusted Level 8 (L8\*):** Level 7 + partial description on how to access the raw data. To assess the the same criteria as in level 3\*. 
-
- - **Adjusted Level 9 (L9\*):**  Level 7 + complete description on how to access the raw data. To assess the the same criteria as in level 4\*.
-
- - **Adjusted Level 10 (L10\*):** Level 9 + computational reproducibility starting from raw data can be certified by a third party researcher (not involved in the original research team). Standards of certification are identical to those of level 5\* 
-
-You will be asked to provide this information in the Assessment and Improvement Survey.
 
 
 ### Reproducibility dimensions at the paper level   


### PR DESCRIPTION
- Make sure that it's consistent whether no data + no code is L1 (in the table) or L0 in the introductory paragraph (line #236)
- Moved the table for admin data reproducibility levels to below the narrative to make sure it's consistent with the sequence in the previous section.
- Reframed L3 vs L4 in the admin data reproducibility scale. I think for the sake of simplicity, we should provide what should be included in the full, complete data access instructions and assign L3 when incomplete, L4 when complete. Some of the items that you provide for L4 are not relevant for some scenarios (e.g. data may be accessible to anyone regardless of geographical location), and I don't think that should be used to reduce the reproducibility level. I think ultimately, the question is whether the instructions are *enough* to get access or not.
- Spelled out the narrative descriptions for all levels. Per Ted's remarks, we should avoid using abbreviations whenever possible.