### PR TITLE
Proposed Change to Introduction

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -18,7 +18,7 @@ output:
   bookdown::html_document2: default
   bookdown::word_document2:
     toc: true
-
+ 
 ---
 #  {-}
 ```{css, echo = FALSE}


### PR DESCRIPTION
1) Hyperlink to "Search Materials" in "(0) Select" Column does not redirect to another page, perhaps can redirect to "Chapter 1 Selecting a Paper" (https://bitss.github.io/ACRE/select.html#select) 

2) Hyperlink to "Read Paper" in "(1) Scoping" also does not redirect to another page, perhaps it can redirect to "2.1 Read and Summarize the Paper" 

3) None of the hyperlinks under the "(4) Robustness" column redirect to the Robustness chapter. 

4)  Column 4 "(3) Improvements" that is split between "Display-item-level" and "Paper-level"- while in the order of the chapters it is clear that these are two different channels of improvement, the table itself is a little unclear in separating the two columns under the header (at first look, I understood the workflow as horizontal between the two columns rather than vertical in each). Maybe something to differentiate these two columns more?