### PR TITLE
Adding a note under 3.1 Describe the inputs

### DIFF
--- a/04-assess.Rmd
+++ b/04-assess.Rmd
@@ -79,7 +79,7 @@ analysis_data_info %>%
     kable_styling(full_width = TRUE) %>%
     scroll_box(width = "100%", box_css = "border: 0px;")
 ```
-
+ 
 ### Describe the code scripts{#desc-scripts}
 
 First, identify all code files in the reproduction package and record their names in the *File Name* column and record their locations relative to the main folder in the *Location* column.


### PR DESCRIPTION
Maybe adding a note could be helpful in section "3.1 Describe the inputs" that explains that not all replication packages include analysis data files, some use the raw data as inputs to produce outputs directly. Not all replication packages include raw data, sometimes there may be access restrictions, etc. such that raw data is not allowed to be redistributed (which is explained later in the chapter).